### PR TITLE
Add OCX flutter app

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "OCX2024/flutter-app"]
+	path = OCX2024/flutter-app
+	url = https://github.com/JKRhb/eclipse_thingweb_app.git


### PR DESCRIPTION
This PR adds the source code of the flutter app we showed at Eclipse OCX 2024 as a git submodule :)

This PR is based on #1, which should be merged first. Afterward, I would rebase this branch against the new `main`.